### PR TITLE
Add mascot image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FairFormer: A Transformer for Discrete Fair Division
 
+![FairFormer mascot](ff.png)
+
 This repository contains the research code accompanying the working paper
 "FairFormer: A transformer architecture for discrete fair division". The model
 implements the two-tower, symmetry-aware transformer described in the draft


### PR DESCRIPTION
## Summary
- add the existing `ff.png` mascot to the README so it displays at the top

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df6430c28832ea0a3483bd2c6a30e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add FairFormer mascot image to the top of the README.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14016ba7d41f39a581e09036866a3556e84a8d14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->